### PR TITLE
Specify targetPlatform 'browser' in worker rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,7 @@ export default [
     output: { dir: 'dist', format: 'esm' },
     plugins: [
       resolve({ extensions }),
-      worker({ platform: 'base64', sourcemap: false }),
+      worker({ platform: 'base64', sourcemap: false, targetPlatform: 'browser' }),
       babel(getBabelOptions({ useESModules: true }, '>1%, not dead, not ie 11, not op_mini all')),
       commonjs(),
     ],
@@ -37,7 +37,7 @@ export default [
     output: { dir: 'dist/debug', format: 'esm' },
     plugins: [
       resolve({ extensions }),
-      worker({ platform: 'base64', sourcemap: true }),
+      worker({ platform: 'base64', sourcemap: true, targetPlatform: 'browser' }),
       babel(getBabelOptions({ useESModules: true }, '>1%, not dead, not ie 11, not op_mini all')),
       commonjs(),
     ],


### PR DESCRIPTION
- Specify targetPlatform 'browser' in worker rollup config
  - Removes node web worker implementation that references `worker_threads`
  - When building with webpack a warning is displayed: `Module not found: Error: Can't resolve 'worker_threads'`  
- The same issue was seen and fixed in use-cannon
  - Issue: https://github.com/pmndrs/use-cannon/issues/351
  - PR: https://github.com/pmndrs/use-cannon/pull/353  